### PR TITLE
Ruby1.9で実行すると invalid multibyte char (US-ASCII) (SyntaxError)とエラーがでるのを修正

### DIFF
--- a/lib/github_scouter.rb
+++ b/lib/github_scouter.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "github_scouter/version"
 require 'octokit'
 


### PR DESCRIPTION
Ruby1.9で実行すると「 invalid multibyte char (US-ASCII) (SyntaxError)」ってエラーがでました。
修正よろしくお願いします。
